### PR TITLE
Added support for iLO4 storage information.

### DIFF
--- a/lib/Net/ILO.pm
+++ b/lib/Net/ILO.pm
@@ -2048,6 +2048,11 @@ sub _serialize {
         return;
     }
 
+    # Since iLO might sometimes return this <INFORM> section, it can make that
+    # response the largest. As a result, the longest compare below might pick
+    # the wrong XML block. Therefore, we strip the <INFORM> section.
+    $data =~ s/<INFORM>Scripting utility should be updated to the latest version\.<\/INFORM>//g;
+
     # iLO returns multiple XML stanzas, all starting with a standard header.
     # We first need to break this glob of data into individual XML components,
     # while ignoring the HTTP header returned by iLO 3.


### PR DESCRIPTION
I've added a patch that adds support for storage information from new iLO4 interfaces, as they are very different from the previous iLO2 and iLO3.

They currently live side by side as two different methods, but it could perhaps be an idea to create a wrapper method that selects the appropriate sub-method based on iLO version. Futureware for now.

This patch also requires the patch from poulhs to resolve some XML::Simple quirks.

Regards,
Anders Synstad
