### PR TITLE
changes to _serialize() to fix bugs with iLO 4

### DIFF
--- a/lib/Net/ILO.pm
+++ b/lib/Net/ILO.pm
@@ -1958,32 +1958,43 @@ sub _serialize {
 
     # iLO returns multiple XML stanzas, all starting with a standard header.
     # We first need to break this glob of data into individual XML components,
-    # while ignoring the HTTP header returned by iLO 3.
+    # while ignoring the HTTP header and trailing data returned by iLO 3.
 
-    chomp( my @stanzas = grep { !/HTTP\/1.1/ } split(/<\?xml.*?\?>/, $data) );
+    # the header is everything up until the first <
+    $data =~ s/^[^<]+//;
+
+    # the trailing text is everything after the last >
+    $data =~ s/[^>]+$//g;
+
+    my @stanzas = grep { !/^<\?xml/ } grep { $_ } split( m|(<\?xml.*?\?>)|, $data);
 
     # @stanzas now contains a number of valid XML sequences.
     # All but one is unnecessary; they contain short status messages and
-    # nothing else. So, we want to parse only the longest message.
+    # nothing else. The one we want has a non-standard XML tag or is the
+    # longest XML stanza.
     #
     # NB: The same status codes are also included in the longest stanza.
 
-    my $longest = ( sort {length($b) <=> length($a)} @stanzas )[0];
-
-    if ($self->_debug > 3) {
-        print Dumper $longest;
-    }
-
-    # XML::Simple croaks if it can't parse the data properly.
-    # We want to capture any errors and propagate them on our own terms.
-
     my $xml;
+    STANZA:
+    foreach my $stanza ( sort { length($a) <=> length($b) } @stanzas ) {
+        if ( $self->_debug > 3 ) {
+            print Dumper $stanza;
+        }
 
-    eval { $xml = XMLin( $longest, NormaliseSpace => 2 ) };
+        # XML::Simple croaks if it can't parse the data properly.
+        # We want to capture any errors and propagate them on our own terms.
+        eval { $xml = XMLin( $stanza ) } or do {
+            $self->error("Error parsing response: $EVAL_ERROR");
+            return;
+        };
 
-    if ($EVAL_ERROR) {
-        $self->error("Error parsing response: $EVAL_ERROR");
-        return;
+        # if this XML stanza has a non-standard tag, it's the one we want
+        foreach my $tag ( keys %{ $xml } ) {
+            if ( $tag ne 'INFORM' && $tag ne 'VERSION' && $tag ne 'RESPONSE' ) {
+                last STANZA;
+            }
+        }
     }
 
     if ($self->_debug >= 2) {

--- a/t/03-serialize.t
+++ b/t/03-serialize.t
@@ -3,7 +3,7 @@
 use strict;
 
 use Net::ILO;
-use Test::More tests => 4;
+use Test::More tests => 5;
 
 my $xml_good = qq|
     <?xml version="1.0"?>
@@ -30,7 +30,40 @@ my $xml_good = qq|
             <TEST_ITEM VALUE="30"/>
         </GET_GLOBAL_SETTINGS>
     </RIBCL>
+    <?xml version="1.0"?>
+    <RIBCL VERSION="2.22">
+        <RESPONSE
+            STATUS="0x0000"
+            MESSAGE='No error'
+        />
+    <INFORM>This is a really long message. Longer even than the GET_GLOBAL_SETTINGS response. It shouldn't be the stanza picked up. The other one should be. So if you see this, something went wrong.</INFORM>
+    </RIBCL>
 |;
+
+my $xml_success_with_inform = qq|
+    <?xml version="1.0"?>
+    <RIBCL VERSION="2.22">
+        <RESPONSE
+            STATUS="0x0000"
+            MESSAGE='No error'
+        />
+    </RIBCL>
+    <?xml version="1.0"?>
+    <RIBCL VERSION="2.22">
+        <RESPONSE
+            STATUS="0x0000"
+            MESSAGE='No error'
+        />
+    <INFORM>Scripting utility should be updated to the latest version.</INFORM>
+    </RIBCL>
+    <?xml version="1.0"?>
+    <RIBCL VERSION="2.22">
+        <RESPONSE
+            STATUS="0x0000"
+            MESSAGE='No error'
+        />
+    </RIBCL>
+|; 
 
 my $xml_bad = qq|
     <?xml version="1.0"?>
@@ -38,7 +71,6 @@ my $xml_bad = qq|
 |;
 
 my $xml_empty = qq||;
-
 
 my $ilo = Net::ILO->new;
 
@@ -50,8 +82,10 @@ my $error_bad    = $ilo->error;
 my $parsed_empty = $ilo->_serialize($xml_empty);
 my $error_empty  = $ilo->error;
 
+my $parsed_success_with_inform = $ilo->_serialize($xml_success_with_inform);
+
 ok( $parsed_good->{GET_GLOBAL_SETTINGS}->{TEST_ITEM}->{VALUE} == 30, 'XML parsed correctly' );
 ok( !$parsed_bad,                                                    'Bad XML sent to parser returns false' );
 ok( !$parsed_empty,                                                  'Null data sent to parser returns false' );
 ok( $error_empty eq 'Error parsing response: no data received',      'Error message set for null data');
-
+ok( $parsed_success_with_inform->{INFORM},                           'When all messages are successful, the longest message is returned'); 


### PR DESCRIPTION
- no longer assumes that the longest stanza is the one we're looking for
  (sometimes that's just a long INFORM message)
- drills down into each xml stanza, looking for tags containing response data
- added unit tests for this